### PR TITLE
make sure "<input"'s matching ">" is outside of quoted string

### DIFF
--- a/webisogetlib.c
+++ b/webisogetlib.c
@@ -604,6 +604,28 @@ void print_cookies(WebGet W)
 
 
 
+/* Find the character ch outside of a quoted string.
+   Return a pointer to the character if found.
+   Return NULL if character not found.  */
+
+static char *find_unquoted(char *str, char ch)
+{
+   char *s = str;
+   while(*s) {
+      if (*s == ch)
+         return s;
+      if (*s == '"') {
+         s++;
+         s = strchr(s,'"');
+         if (s == NULL)
+            return s;
+      }
+      s++;
+   }
+   return NULL;
+}
+
+
 /* Find the value for key 'name' in the string.
    Return empty string if keyword only.
    Return NULL if keyword not found. 
@@ -952,7 +974,7 @@ static Form isaform(WebPage page)
                 int userv = 0;
                 int subtype = 0;
          
-                e = strchr(s, '>');
+                e = find_unquoted(s, '>');
                 if (!e) break;  /* invalid */
                 *e = '\0';
          


### PR DESCRIPTION
This pull request makes webisoget work with login.cern.ch's X.509 certificate authentication.   A form response there includes a ">" inside of a double-quoted string which webisoget treated prematurely as the end of the "<input" section.

 (To use the X.509 certificate you also need to pre-populate cookie cache with `SSOAutologonCertificate=true; domain=login.cern.ch; path=/` and use `-form "name=hiddenform;"`.)
