### PR TITLE
allow compilation without CURLOPT_RESOLVE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,14 +71,14 @@ AC_CHECK_LIB(curl,curl_easy_init,,
       [-lssl -lcrypto -lz])
 AC_CHECK_HEADER([curl/curl.h])
 
-# check for right version of curl
-AC_MSG_NOTICE([Checking libcurl version.])
-AC_LINK_IFELSE([
-  AC_LANG_SOURCE([[
-#include <curl/curl.h>
-int main(){ CURL *c; curl_easy_setopt(c, CURLOPT_RESOLVE, NULL);}
-]])]
-,[],[AC_MSG_ERROR(libcurl does not support CURLOPT_RESOLVE. (vers 7.30+))]) 
+## check for right version of curl
+#AC_MSG_NOTICE([Checking libcurl version.])
+#AC_LINK_IFELSE([
+#  AC_LANG_SOURCE([[
+##include <curl/curl.h>
+#int main(){ CURL *c; curl_easy_setopt(c, CURLOPT_RESOLVE, NULL);}
+#]])]
+#,[],[AC_MSG_ERROR(libcurl does not support CURLOPT_RESOLVE. (vers 7.30+))]) 
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -71,14 +71,14 @@ AC_CHECK_LIB(curl,curl_easy_init,,
       [-lssl -lcrypto -lz])
 AC_CHECK_HEADER([curl/curl.h])
 
-## check for right version of curl
-#AC_MSG_NOTICE([Checking libcurl version.])
-#AC_LINK_IFELSE([
-#  AC_LANG_SOURCE([[
-##include <curl/curl.h>
-#int main(){ CURL *c; curl_easy_setopt(c, CURLOPT_RESOLVE, NULL);}
-#]])]
-#,[],[AC_MSG_ERROR(libcurl does not support CURLOPT_RESOLVE. (vers 7.30+))]) 
+# check for right version of curl
+AC_MSG_NOTICE([Checking libcurl version.])
+AC_LINK_IFELSE([
+  AC_LANG_SOURCE([[
+#include <curl/curl.h>
+int main(){ CURL *c; curl_easy_setopt(c, CURLOPT_RESOLVE, NULL);}
+]])]
+,[],[AC_MSG_NOTICE(libcurl does not support CURLOPT_RESOLVE (needs vers 7.30+) --  map command wll not work)]) 
 
 
 

--- a/webisoget.c
+++ b/webisoget.c
@@ -211,8 +211,13 @@ static int docmd(WebGet W, char *cmd, char *arg)
       add_anchor(W, arg);
 
    } else if (!strcmp(cmd,"map")) {
+#ifdef CURLOPT_RESOLVE
       if (!arg) usage();
       add_host_map(W, arg);
+#else
+      fprintf(stderr, "map command requires CURLOPT_RESOLVE from libcurl 7.30+\n");
+      return (0);
+#endif
 
    } else if (!strcmp(cmd,"postdata")) {
       if (!arg) usage();

--- a/webisogetlib.c
+++ b/webisogetlib.c
@@ -240,6 +240,7 @@ char *get_dottedip(char *host) {
    return (NULL);
 }
 
+#ifdef CURLOPT_RESOLVE
 void add_host_map(WebGet W, char *str)
 {
    HostMap m;
@@ -264,6 +265,7 @@ void add_host_map(WebGet W, char *str)
       free(realname);
    }
 }
+#endif
 
 
 /* parse URL */
@@ -1455,6 +1457,7 @@ WebPage get_one_page(WebGet W, char *urlstr, Form form)
    // curl_easy_setopt(W->curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
    curl_easy_setopt(W->curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_DEFAULT);
 
+#ifdef CURLOPT_RESOLVE
    /* check for mapped host */
    HostMap M;
    for (M=W->host_maps; M; M=M->next) {
@@ -1472,6 +1475,7 @@ WebPage get_one_page(WebGet W, char *urlstr, Form form)
       fakehost = curl_slist_append(NULL, fakeip);
       curl_easy_setopt(W->curl, CURLOPT_RESOLVE, fakehost);
    }
+#endif
 
    /* add user's headers */
    


### PR DESCRIPTION
For those who don't need to use the map function, this pull request allows compilation on older operating systems without a libcurl version >= 7.30