### PR TITLE
Clarify install documentation

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,8 +1,13 @@
 
-Install with:
+Extra packages required:
 
-# ./configure
-# make
+libtool, autoconf, automake, gcc, libcurl-devel, openssl-devel
+
+Install with:        
+
+$ bash ./boot
+$ ./configure
+$ make
 # make install
 
 Or with:

--- a/README
+++ b/README
@@ -14,15 +14,20 @@ c programs.  Use webisoget.c as a guide to the API.
 Author:  Jim Fox, University of Washington, fox@washington.edu
 --------------------------------------------------------------
 
+Extra packages required:
+
+libtool, autoconf, automake, gcc, libcurl-devel, openssl-devel
+
 Install with:
 
-# ./configure
-# make
+$ bash ./boot
+$ ./configure
+$ make
 # make install
 
 To upgrade, best to clean first
-# make clean
-# make
+$ make clean
+$ make
 # make install
 
 


### PR DESCRIPTION
Installation notes in INSTALL and README currently show:
```
# ./configure
# make
# make install
```
But after cloning the repo, there is no 'configure' script to execute. First, the commands in 'boot' need to be run. I added that step explicitly, and also provided a note about packages that need to be installed (that are probably not installed on systems where software isn't regularly built/installed in this manner).